### PR TITLE
Feature: align storage api with Arcane UI

### DIFF
--- a/src/services/extraNodeInformationService.js
+++ b/src/services/extraNodeInformationService.js
@@ -8,7 +8,7 @@ async function getData(adminFluxId) {
   const database = db.db(config.database.database);
   const notificationCollection = config.collections.notifications;
   const query = { adminId: adminFluxId };
-  const notificationRes = await serviceHelper.findOneInDatabase(database, notificationCollection, query, {});
+  const notificationRes = await serviceHelper.findOneInDatabase(database, notificationCollection, query, { _id: 0 });
   return notificationRes;
 }
 
@@ -17,7 +17,7 @@ async function getDataFromWords(words) {
   const database = db.db(config.database.database);
   const notificationCollection = config.collections.notifications;
   const query = { words };
-  const notificationRes = await serviceHelper.findOneInDatabase(database, notificationCollection, query, {});
+  const notificationRes = await serviceHelper.findOneInDatabase(database, notificationCollection, query, { _id: 0 });
   return notificationRes;
 }
 
@@ -29,7 +29,7 @@ async function postData(data) {
   const timestamp = new Date().getTime();
   // eslint-disable-next-line no-param-reassign
   data.timestamp = timestamp;
-  await serviceHelper.updateOneInDatabase(database, notificationCollection, query, { $set: data }, { upsert: true });
+  await serviceHelper.replaceOneInDatabase(database, notificationCollection, query, data, { upsert: true });
 }
 
 module.exports = {

--- a/src/services/serviceHelper.js
+++ b/src/services/serviceHelper.js
@@ -168,6 +168,12 @@ async function insertOneToDatabase(database, collection, value) {
   return result;
 }
 
+async function replaceOneInDatabase(database, collection, query, replace, options) {
+  const passedOptions = options || {};
+  const result = await database.collection(collection).replaceOne(query, replace, passedOptions);
+  return result;
+}
+
 async function updateOneInDatabase(database, collection, query, update, options) {
   const passedOptions = options || {};
   const result = await database.collection(collection).updateOne(query, update, passedOptions);
@@ -333,6 +339,7 @@ module.exports = {
   insertOneToDatabase,
   updateInDatabase,
   updateOneInDatabase,
+  replaceOneInDatabase,
   findOneAndDeleteInDatabase,
   removeDocumentsFromCollection,
   dropCollection,


### PR DESCRIPTION
Fixes a couple of issues with the storage of node "extradata".

Note - I don't have an environment to test these changes fully, have only done partial testing.

When you choose to upload your data on the api, it does a database update, instead of a replace. This will lead to issues where someones changes notification preferences. It also means you can never delete data.

For example:

Say I use Telegram in the past, and then switch to Discord, I will end up with both notifications settings, and can never update. Edit: well you could, but would then have to post empty telegram data, but it gets messy

Changes:

* Update success response to be standard “data message” format, so the Arcane UI can validate the response
* Update keys to match the Arcane configure UI (don’t have to translate)
* Only store the keys that have been posted
* Add db method for replacing data, and use that instead of update
* Remove the _id internal db key from api data